### PR TITLE
feat: Add level 5 to the game

### DIFF
--- a/src/game/level/level05.rs
+++ b/src/game/level/level05.rs
@@ -1,0 +1,28 @@
+use crate::game::constants::TOTAL_TILES;
+use crate::game::Position;
+
+const TERRAINS: [&str; TOTAL_TILES] = [
+    "G1","G2","G1","G2","G1","G2","G1","G2","G1","G2","G1","G2",
+    "G3","G4","G3","G4","G3","G4","G3","G4","G3","G4","G3","G4",
+    "G1","G2","G1","G2","G1","G2","G1","G2","G1","G2","G1","G2",
+    "G3","G4","G3","G4","G3","G4","G3","G4","G3","G4","G3","G4",
+    "G1","G2","G1","G2","G1","G2","G1","G2","G1","G2","G1","G2",
+    "G3","G4","G3","G4","G3","G4","G3","G4","G3","G4","G3","G4",
+    "G1","G2","G1","G2","G1","G2","G1","G2","G1","G2","G1","G2",
+    "G3","G4","G3","G4","G3","G4","G3","G4","G3","G4","G3","G4"
+];
+
+const OBJECTS: [&str; TOTAL_TILES] = [
+    "W ","W ","W ","W ","W ","W ","W ","W ","W ","W ","W ","W ",
+    "W ","  ","  ","R ","BW","BW","BW","R ","  ","  ","CL","W ",
+    "W ","  ","H ","T ","BW","C ","BW","T ","CD","  ","  ","W ",
+    "W ","R ","T ","  ","BW","BW","BW","  ","T ","R ","  ","W ",
+    "W ","  ","  ","R ","  ","FS","  ","R ","  ","  ","CR","W ",
+    "W ","T ","BW","BW","BW","BW","BW","BW","BW","T ","  ","W ",
+    "W ","  ","R ","  ","  ","CU","  ","  ","R ","  ","RF","W ",
+    "W ","W ","W ","W ","W ","W ","W ","W ","W ","W ","W ","W "
+];
+
+const PLAYER_POSITION: Position = Position(1f64, 1f64); // Corresponds to (row 1, col 1) -> OBJECTS[1*12+1]
+
+pub const LEVEL05: ([&str; TOTAL_TILES], [&str; TOTAL_TILES], Position) = (TERRAINS, OBJECTS, PLAYER_POSITION);

--- a/src/game/level/level_manager.rs
+++ b/src/game/level/level_manager.rs
@@ -110,13 +110,15 @@ use super::level01::LEVEL01;
 use super::level02::LEVEL02;
 use super::level03::LEVEL03;
 use super::level04::LEVEL04;
+use super::level05::LEVEL05;
 
 pub type Level = ([&'static str; TOTAL_TILES], [&'static str; TOTAL_TILES], Position);
-pub const LEVELS: [Level; 4] = [
+pub const LEVELS: [Level; 5] = [
     LEVEL01,
     LEVEL02,
     LEVEL03,
     LEVEL04,
+    LEVEL05,
 ];
 
 pub struct LevelManager {


### PR DESCRIPTION
A new level, LEVEL05, has been added to the game.

This includes:
- A new level definition file `src/game/level/level05.rs` with unique terrain and object layout.
- Registration of `LEVEL05` in `src/game/level/level_manager.rs`.

The level selection UI and game constants are designed to dynamically adapt to the number of levels, so no direct changes were needed in those areas to support the new level.